### PR TITLE
Bind http.server on all available interfaces

### DIFF
--- a/templates/server.sh.j2
+++ b/templates/server.sh.j2
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -e
-/usr/local/bin/python -m http.server {{ port }} &
+/usr/local/bin/python -m http.server --bind :: {{ port }} &
 # if [ ! -z $LOG_PERIOD_SEC ] && [ ! -z $MESSAGE_LEN ] && [ ! -z $POD_NAME ]; then
 #     DIV=$(echo "scale=3; $LOG_PERIOD_SEC" | bc)
 #     while true; do 


### PR DESCRIPTION
Currently the http server bind only on ipv4 interfaces. When running the image on single stack IPv6 environment the server is not available. This change allows the server to bind on all interfaces.