### PR TITLE
Support IPv4 and IPv6/dual-stack networking

### DIFF
--- a/templates/server.sh.j2
+++ b/templates/server.sh.j2
@@ -1,3 +1,6 @@
 #!/bin/sh
 
-/usr/local/bin/python -m http.server --bind :: {{ port }}
+BIND_OPTS=""
+[ -f /proc/net/if_inet6 ] && BIND_OPTS="--bind ::"
+
+/usr/local/bin/python -m http.server $BIND_OPTS {{ port }}


### PR DESCRIPTION
Only pass '--bind ::' when IPv6 is enabled. If this option is passed on a system with IPv4 single-stack networking, the container exits with the following error:

Traceback (most recent call last):
  File "/usr/local/lib/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/local/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/usr/local/lib/python3.9/http/server.py", line 1289, in <module>
    test(
  File "/usr/local/lib/python3.9/http/server.py", line 1244, in test
    with ServerClass(addr, HandlerClass) as httpd:
  File "/usr/local/lib/python3.9/socketserver.py", line 448, in __init__
    self.socket = socket.socket(self.address_family,
  File "/usr/local/lib/python3.9/socket.py", line 232, in __init__
    _socket.socket.__init__(self, family, type, proto, fileno)
OSError: [Errno 97] Address family not supported by protocol